### PR TITLE
feat: disable mobile swipe gestures

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   }
   canvas {
     background:#000;border:2px solid #444;
-    display:block;margin:auto
+    display:block;margin:auto;
+    touch-action:none;
   }
 </style>
 </head>
@@ -337,8 +338,8 @@ function handleTouch(e){
   paddleX=Math.min(Math.max(touchX-paddleWidth/2,0),canvas.width-paddleWidth);
   e.preventDefault();
 }
-canvas.addEventListener("touchstart",handleTouch);
-canvas.addEventListener("touchmove",handleTouch);
+canvas.addEventListener("touchstart", handleTouch, { passive: false });
+canvas.addEventListener("touchmove", handleTouch, { passive: false });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prevent default swipe behaviour on mobile by adding `touch-action: none` to the game canvas
- mark touch listeners as non-passive so `preventDefault` stops swipe interactions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b820bbd6488330b405f7cd36423d3c